### PR TITLE
roles were hardcoded - now requested from db

### DIFF
--- a/app/middleware/verifySignUp.js
+++ b/app/middleware/verifySignUp.js
@@ -1,5 +1,4 @@
 const db = require("../models");
-const ROLES = db.ROLES;
 const User = db.user;
 
 checkDuplicateUsernameOrEmail = async (req, res, next) => {
@@ -38,10 +37,14 @@ checkDuplicateUsernameOrEmail = async (req, res, next) => {
   }
 };
 
-checkRolesExisted = (req, res, next) => {
+checkRolesExisted = async (req, res, next) => {
+  const roles = await db.role.findAll()
+  let roleNames = []
+  roles.forEach(role => roleNames.push(role.name))
+
   if (req.body.roles) {
     for (let i = 0; i < req.body.roles.length; i++) {
-      if (!ROLES.includes(req.body.roles[i])) {
+      if (!roleNames.includes(req.body.roles[i])) {
         res.status(400).send({
           message: "Failed! Role does not exist = " + req.body.roles[i]
         });

--- a/app/models/index.js
+++ b/app/models/index.js
@@ -38,6 +38,4 @@ db.user.belongsToMany(db.role, {
   otherKey: "roleId"
 });
 
-db.ROLES = ["user", "admin", "moderator"];
-
 module.exports = db;


### PR DESCRIPTION
Roles are already created in the initial function in server.js. With `db.ROLES = ["user", "admin", "moderator"];` in app/models/index.js they are double hardcoded. In checkRolesExisted function they are now pulled from database instead of read from db.ROLES

Btw. thank you very much for your repos and tutorials, they really helped me getting a grasp of JWT auth! Keep up the good work!